### PR TITLE
NETOBSERV-2912: Enable PQC in OpenSSL: switch to ubi-minimal-pqc base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
 ARG TARGETARCH=amd64
 
+# PQC crypto-policies builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS crypto-builder
+RUN microdnf install -y crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all && rm -rf /var/cache/*
+
 # Build the manager binary
 FROM docker.io/library/golang:1.26 AS builder
 
@@ -33,13 +39,14 @@ RUN USER=netobserv VERSION=main make oc-commands
 RUN mkdir -p output
 
 # Create final image from ubi + built binary and command
-FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1784092978
 
 RUN microdnf install -y tar && \
     microdnf clean all
 
 WORKDIR /
 
+COPY --from=crypto-builder /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=builder /opt/app-root/build .
 COPY --from=builder --chown=65532:65532 /opt/app-root/output /output
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN USER=netobserv VERSION=main make oc-commands
 RUN mkdir -p output
 
 # Create final image from ubi + built binary and command
-FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1784092978
+FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
 
 RUN microdnf install -y tar && \
     microdnf clean all


### PR DESCRIPTION
## Description

Enable `DEFAULT:PQ` crypto policy for post-quantum cryptography support using a multi-stage build. A `crypto-builder` stage installs `crypto-policies-scripts`, configures `DEFAULT:PQ`, and the resulting `/etc/crypto-policies/` is copied into the runtime image. This makes ML-KEM available via OpenSSL without changing the base image.

This is part of the OCP 5.0 PQC initiative ([OCPSTRAT-3113](https://issues.redhat.com/browse/OCPSTRAT-3113)). The crypto policy switch is transparent to the CLI — it does not alter behavior or APIs.

**Approach:** Based on [openshift/images#230](https://github.com/openshift/images/pull/230).

**Verification:**
```bash
podman build -t cli-pqc-test -f Dockerfile .
podman run --rm --entrypoint cat cli-pqc-test /etc/crypto-policies/state/current
# Output: DEFAULT:PQ
```

**Images updated:**
- `Dockerfile` (CLI image)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [NETOBSERV-2912](https://redhat.atlassian.net/browse/NETOBSERV-2912)`